### PR TITLE
Remove misbehaving debug log

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -307,7 +307,6 @@ where
                     initial_count += 1;
                     let mut internals = self.0.internals.lock().await;
                     if initial_count == initial_size {
-                        debug!("initial ok");
                         internals.is_initial_done = true;
                         break
                     }


### PR DESCRIPTION
Seems that when using log macros inside of a `select!`, we skip all log filters and the actual logger implementation, which is in our case `tracing`. As you can see from our log output the `initial ok` is not coming from `tracing-subscriber` in JSON format. Nothing else from `mobc` debug logs is displayed, which should be the correct behavior.

``` json
{"timestamp":"Nov 27 12:19:20.793","level":"INFO","target":"quaint::pooled","fields":{"message":"Starting a mysql pool with 49 connections.","log.target":"quaint::pooled","log.module_path":"quaint::pooled","log
.file":"/home/pimeys/.cargo/git/checkouts/quaint-9f01e008b9a89c14/d4456af/src/pooled.rs","log.line":134}}
initial ok
{"timestamp":"Nov 27 12:19:20.804","level":"INFO","target":"prisma::server","fields":{"message":"Started http server on 0.0.0.0:4466","log.target":"prisma::server","log.module_path":"prisma::server","log.file":
"query-engine/prisma/src/server.rs","log.line":48}}
```