### PR TITLE
Panic if min_idle is 0

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -77,7 +77,14 @@ where
     /// connections at all times, while respecting the value of `max_size`.
     ///
     /// Defaults to `None` (equivalent to the value of `max_size`).
+    ///
+    /// # Panics
+    ///
+    /// Panics if `min_idle` is 0.
     pub fn min_idle(mut self, min_idle: Option<u32>) -> Self {
+        if let Some(min_idle) = min_idle {
+            assert!(min_idle > 0, "min_idle must be positive");
+        }
         self.min_idle = min_idle;
         self
     }


### PR DESCRIPTION
Right now `min_idle`=`Some(0)` leads to an ignored timeout in `.build()` as well as a timeout error in each `.get()`. A panic while building the configuration sounds much better to me. The alternative would be to add a few special cases to the code to handle this correctly but I don't think that's worth it.