### PR TITLE
feat: update redis dependency to 0.17

### DIFF
--- a/mobc-redis/Cargo.toml
+++ b/mobc-redis/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mobc-redis"
-version = "0.5.3"
+version = "0.5.4"
 authors = ["importcjj <importcjj@gmail.com>"]
 edition = "2018"
 license = "MIT/Apache-2.0"
@@ -12,7 +12,7 @@ keywords = ["redis", "pool", "async", "await"]
 
 [dependencies]
 mobc = { version = "0.5", path = ".." }
-redis = "0.16"
+redis = "0.17"
 
 [dev-dependencies]
 actix-web = "2.0.0"


### PR DESCRIPTION
The 0.17 version of the `redis` crate contains TLS/SSL support.