### PR TITLE
Upgrade tokio to 0.3 for mobc-redis

### DIFF
--- a/mobc-redis/Cargo.toml
+++ b/mobc-redis/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mobc-redis"
-version = "0.5.4"
+version = "0.6.0"
 authors = ["importcjj <importcjj@gmail.com>"]
 edition = "2018"
 license = "MIT/Apache-2.0"
@@ -11,11 +11,12 @@ keywords = ["redis", "pool", "async", "await"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-mobc = { version = "0.5", path = ".." }
-redis = "0.17"
+mobc = { version = "0.6", path = ".." }
+redis = { version = "0.18", features = ["aio"] }
 
 [dev-dependencies]
 actix-web = "2.0.0"
 actix-rt = "1.0"
 actix-http = "1.0"
-tokio = { version = "0.2", features = ["full"]}
+tokio = { version = "0.3", features = ["full"]}
+redis = { version = "0.18", features = ["tokio-comp"] }

--- a/mobc-redis/README.md
+++ b/mobc-redis/README.md
@@ -1,5 +1,4 @@
 # mobc-redis
-=============
 
 [![crates.io](https://img.shields.io/badge/crates.io-latest-%23dea584)](https://crates.io/crates/mobc-redis)
 

--- a/mobc-redis/README.md
+++ b/mobc-redis/README.md
@@ -1,3 +1,13 @@
+# mobc-redis
+=============
+
+[![crates.io](https://img.shields.io/badge/crates.io-latest-%23dea584)](https://crates.io/crates/mobc-redis)
+
+[Documentation](https://docs.rs/mobc-redis)
+
+## Example 
+
+```rust
 use mobc::Pool;
 use mobc_redis::RedisConnectionManager;
 use redis::AsyncCommands;
@@ -29,3 +39,26 @@ async fn main() {
 
     println!("cost: {:?}", now.elapsed());
 }
+```
+
+## Runtimes
+
+You can use either [tokio](https://github.com/tokio-rs/tokio), or [async-std](https://github.com/async-rs/async-std) as your async runtime.
+
+You need to use a different dependency setup for them, though and you have to set the [redis-rs](https://github.com/mitsuhiko/redis-rs) dependency yourself to either `tokio-comp`, or `async-std-comp`.
+
+### tokio
+
+```
+mobc = "0.6"
+mobc-redis = "0.6"
+redis = { version = "0.18", features = ["tokio-comp"] }
+```
+
+### async-std
+
+```
+mobc = {version = "0.6", features = ["async-std"] }
+mobc-redis = "0.6"
+redis = { version = "0.18", features = ["async-std-comp"] }
+```

--- a/mobc-redis/examples/actix-web.rs
+++ b/mobc-redis/examples/actix-web.rs
@@ -1,7 +1,6 @@
 use actix_web::{web, App, HttpServer, Responder};
-use mobc_redis::AsyncCommands;
 use mobc_redis::RedisConnectionManager;
-use mobc_redis::{redis, Connection};
+use redis::AsyncCommands;
 
 type Pool = mobc::Pool<RedisConnectionManager>;
 

--- a/mobc-redis/src/lib.rs
+++ b/mobc-redis/src/lib.rs
@@ -1,9 +1,7 @@
-  
 use mobc::async_trait;
 use mobc::Manager;
-pub use redis;
-pub use redis::aio::Connection;
-pub use redis::AsyncCommands;
+use redis;
+use redis::aio::Connection;
 use redis::{Client, ErrorKind};
 
 pub struct RedisConnectionManager {
@@ -29,9 +27,8 @@ impl Manager for RedisConnectionManager {
     async fn check(&self, mut conn: Self::Connection) -> Result<Self::Connection, Self::Error> {
         let pong: String = redis::cmd("PING").query_async(&mut conn).await?;
         if pong.as_str() != "PONG" {
-            return Err((ErrorKind::ResponseError, "pong response error").into())
+            return Err((ErrorKind::ResponseError, "pong response error").into());
         }
         Ok(conn)
     }
 }
-


### PR DESCRIPTION
Hello!

This is my attempt at upgrading tokio to 0.3 for mobc-redis.

The problem I ran into is, that in the newest [redis-rs](https://github.com/mitsuhiko/redis-rs) version with tokio 0.3, redis-rs 0.18, you have to explicitly set either `tokio-comp`, or `async-std-comp`.

And since it's to my knowledge not possible to set features within features (e.g. that the `tokio` feature on `mobc-redis` would use `redis-rs` with `tokio-comp` and the same with `async-std`), the `redis` dependency can't be re-exported anymore and needs to be explicitly set when using `mobc-redis`, setting either `tokio-comp`, or `async-std-comp`.

I added a `README.md`, with an example, which explains this situation.

If you have a different approach, or idea how to solve this, feel free to close, or change this any way you like. :relaxed: 