### PR TITLE
Prevent timeout of queries

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -653,17 +653,17 @@ async fn put_conn<M: Manager>(
 
     conn.brand_new = false;
 
-    if internals.conn_requests.len() > 0 {
+    while internals.conn_requests.len() > 0 {
         let req = internals.conn_requests.pop_front().unwrap();
         internals.wait_count -= 1;
 
         if req.is_canceled() {
-            return put_idle_conn(shared, internals, conn);
+            continue;
         }
 
-        // FIXME
-        if let Err(conn) = req.send(conn) {
-            return put_idle_conn(shared, internals, conn);
+        if let Err(c) = req.send(conn) {
+            conn = c;
+            continue;
         }
         return;
     }


### PR DESCRIPTION
This an attempt at fixing https://github.com/importcjj/mobc/issues/52
As I said, pretty green in Rust code but this does compile and pass tests.
I am guessing we need more tests to verify this timing issue and I am happy to help on that (need ideas of scenarios and help on implementing them).