### PR TITLE
Add idle check to connection cleaner and rework when it runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,11 +107,15 @@ Sets the maximum idle connection count maintained by the pool. The pool will mai
 
 #### max_lifetime
 Sets the maximum lifetime of connections in the pool. Expired connections may be closed lazily before reuse.
->None meas reuse forever, defaults to None.
+>None means reuse forever, defaults to None.
+
+#### max_idle_lifetime
+Sets the maximum idle lifetime of connections in the pool. Expired connections may be closed lazily before reuse.
+>None means reuse forever, defaults to None.
 
 #### get_timeout
 Sets the get timeout used by the pool. Calls to Pool::get will wait this long for a connection to become available before returning an error. 
->None meas never timeout, defaults to 30 seconds.
+>None means never timeout, defaults to 30 seconds.
 
 
 ## Variable
@@ -121,6 +125,7 @@ Some of the connection pool configurations can be adjusted dynamically. Each con
 * set_max_open_conns
 * set_max_idle_conns
 * set_conn_max_lifetime
+* set_conn_max_idle_lifetime
 
 ## Stats
 * max_open - Maximum number of open connections to the database.
@@ -131,8 +136,7 @@ Some of the connection pool configurations can be adjusted dynamically. Each con
 * wait_duration - The total time blocked waiting for a new connection.
 * max_idle_closed - The total number of connections closed due to max_idle.
 * max_lifetime_closed - The total number of connections closed due to max_lifetime.
+* max_lifetime_idle_closed - The total number of connections closed due to max_idle_lifetime.
 
 ## Compatibility
 Because tokio is not compatible with other runtimes, such as async-std. So a database driver written with tokio cannot run in the async-std runtime. For example, you can't use redis-rs in tide because it uses tokio, so the connection pool which bases on redis-res can't be used in tide either.
-
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -802,17 +802,15 @@ async fn clean_connection<M: Manager>(shared: &Weak<SharedPool<M>>) -> bool {
         return true;
     }
 
-    let expired = if let Some(lifetime) = internals.config.max_lifetime {
-        Some(Instant::now() - lifetime)
-    } else {
-        None
-    };
+    let expired = internals
+        .config
+        .max_lifetime
+        .map(|lifetime| Instant::now() - lifetime);
     let mut closing = vec![];
-    let idle_expired = if let Some(lifetime) = internals.config.max_idle_lifetime {
-        Some(Instant::now() - lifetime)
-    } else {
-        None
-    };
+    let idle_expired = internals
+        .config
+        .max_idle_lifetime
+        .map(|lifetime| Instant::now() - lifetime);
     let mut idle_closing = vec![];
 
     let mut i = 0;


### PR DESCRIPTION
Fixes https://github.com/importcjj/mobc/issues/58

So this is somewhat of a big change:
- The connection cleaner now checks for the idle lifetime (time since last used). The current lazy only technique is not sufficient for production systems that might receive a spike in demand but want to avoid holding useless connections when the demand is reduced.
- The connection cleaner is now started on pool launch if either the max idle lifetime or max lifetime is set. Previously it was only started when it was changed with the set method which doesn't really make sense.
- Added a method on the pool to dynamically change the max idle lifetime
- The cleaner now lives much longer and only stops if both max lifetime are none. Previously it would stop if the number of open connections was 0 and could only restart if the lifetime was changed. This would mean that it would stop on reduced demand (or no demand) but would not start again later on.

I added tests to reflect the new behaviour but let me know if you want more.