### PR TITLE
Add bolt-client to supported backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ mobc = "0.8"
 
 | Backend                                                                                   | Adaptor Crate                                                           |
 | ----------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
+| [bolt-client](https://crates.io/crates/bolt-client)                                       | [mobc-bolt](https://crates.io/crates/mobc-bolt)                         |
 | [tokio-postgres](https://github.com/sfackler/rust-postgres)                               | [mobc-postgres](https://github.com/importcjj/mobc-postgres)             |
 | [redis](https://github.com/mitsuhiko/redis-rs)                                            | [mobc-redis](https://github.com/importcjj/mobc-redis)                   |
 | [arangodb](https://github.com/fMeow/arangors)                                             | [mobc-arangors](https://github.com/inzanez/mobc-arangors)               |


### PR DESCRIPTION
This adds [mobc-bolt](https://crates.io/crates/mobc-bolt) to the README.