### PR TITLE
fix: Change from channels to use a Semaphore

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -605,7 +605,7 @@ async fn put_conn<M: Manager>(
     mut internals: MutexGuard<'_, PoolInternals<M::Connection, M::Error>>,
     mut conn: Conn<M::Connection, M::Error>,
 ) {
-    if conn_still_valid(shared, &internals, &mut conn) {
+    if conn_still_valid(shared, &mut conn) {
         conn.brand_new = false;
         put_idle_conn(shared, internals, conn);
     } else {
@@ -617,14 +617,9 @@ async fn put_conn<M: Manager>(
 
 fn conn_still_valid<M: Manager>(
     shared: &Arc<SharedPool<M>>,
-    internals: &MutexGuard<'_, PoolInternals<M::Connection, M::Error>>,
     conn: &mut Conn<M::Connection, M::Error>,
 ) -> bool {
     if conn.raw.is_none() {
-        return false;
-    }
-
-    if internals.config.max_open > 0 && internals.num_open > internals.config.max_open {
         return false;
     }
 

--- a/tests/mobc.rs
+++ b/tests/mobc.rs
@@ -402,7 +402,7 @@ fn test_lazy_initialization_failure() {
         let err = pool.get().await.err().unwrap();
         match err {
             Error::Inner(TestError) => (),
-            _ => panic!("{:?} expected"),
+            _ => panic!("expected"),
         }
 
         Ok::<(), Error<TestError>>(())
@@ -445,7 +445,7 @@ fn test_idle_timeout_partial_use() {
 
     struct Handler {
         num: AtomicIsize,
-    };
+    }
 
     #[async_trait]
     impl Manager for Handler {

--- a/tests/mobc.rs
+++ b/tests/mobc.rs
@@ -561,7 +561,7 @@ fn test_set_conn_max_lifetime() {
 
     struct Handler {
         num: AtomicIsize,
-    };
+    }
 
     #[async_trait]
     impl Manager for Handler {


### PR DESCRIPTION
When under very heavy load, the conn_requests can include to many
Sender's with dropped Receivers. When the Conn is passed to a waiting
Receiver and it was recently dropped the Conn could be lost causing
a mis-count on the `num_open` stat which stops any new connections
from being created and then mobc deadlocks.

This fixes it by switching from a oneshot channel and queue to using a
Semaphore to keep track of available connections for any requests.

This fixes https://github.com/importcjj/mobc/issues/63