### PR TITLE
chore: Update deps and readme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## v0.8.1
+
+- Fix typo's in readme
+- Update mobc-postgres and mobc-redis to use latest version
+
 ## v0.8.0
 
 - Replaces channels with Sempahores

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mobc"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["importcjj <importcjj@gmail.com>", "Garren Smith <garren.smith@gmail.com>"]
 edition = "2018"
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# Prisma Mobc
+# Mobc
 
 A generic connection pool with async/await support.
 
 Inspired by Deadpool, Sqlx, r2d2 and Golang SQL package.
 
-[Changelog](https://github.com/prisma/mobc/blob/main/CHANGELOG.md)
+[Changelog](https://github.com/importcjj/mobc/blob/main/CHANGELOG.md)
 
-**Note: mobc requires at least Rust 1.39.**
+**Note: mobc requires at least Rust 1.60.**
 
 ## Usage
 
@@ -46,7 +46,7 @@ More DB adaptors are welcome.
 
 ## Examples
 
-More [examples](https://github.com/importcjj/mobc/tree/master/mobc-foo/examples)
+More [examples](https://github.com/importcjj/mobc/tree/main/examples)
 
 Using an imaginary "foodb" database.
 

--- a/mobc-postgres/Cargo.toml
+++ b/mobc-postgres/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mobc-postgres"
 version = "0.7.0"
-authors = ["importcjj <importcjj@gmail.com>"]
+authors = ["importcjj <importcjj@gmail.com>", "Garren Smith <garren.smith@gmail.com>"]
 edition = "2018"
 readme = "README.md"
 license = "MIT/Apache-2.0"
@@ -22,7 +22,7 @@ with-uuid-0_8 = ["tokio-postgres/with-uuid-0_8"]
 
 [dependencies]
 tokio-postgres = "0.7.0"
-mobc = { version = "0.7", path = ".." }
+mobc = { version = "0.8", path = ".." }
 futures = "0.3"
 
 [dev-dependencies]

--- a/mobc-redis/Cargo.toml
+++ b/mobc-redis/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mobc-redis"
 version = "0.7.0"
-authors = ["importcjj <importcjj@gmail.com>"]
+authors = ["importcjj <importcjj@gmail.com>", "Garren Smith <garren.smith@gmail.com>"]
 edition = "2018"
 license = "MIT/Apache-2.0"
 description = "Redis support for the mobc connection pool"
@@ -11,8 +11,8 @@ keywords = ["redis", "pool", "async", "await"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-mobc = { version = "0.7", path = ".." }
-redis = { version = "0.19" }
+mobc = { version = "0.8", path = ".." }
+redis = { version = "0.22.2" }
 
 [features]
 default = ["mobc/tokio", "redis/tokio-comp"]


### PR DESCRIPTION
Update mobc-redis and mobc-postgres to use latest version. Fixed typo's in the readme from the Prisma fork.