### PR TITLE
fix: open connections metrics increment

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -541,8 +541,8 @@ impl<M: Manager> Pool<M> {
         match self.0.manager.connect().await {
             Ok(c) => {
                 self.0.state.num_open.fetch_add(1, Ordering::Relaxed);
-                increment_gauge!(OPENED_TOTAL, 1.0);
-                increment_counter!(OPEN_CONNECTIONS);
+                increment_gauge!(OPEN_CONNECTIONS, 1.0);
+                increment_counter!(OPENED_TOTAL);
 
                 let conn = Conn {
                     raw: Some(c),


### PR DESCRIPTION
Fixes #73 

When a new connection was opened, the `mobc_pool_connections_opened_total` metric was incremented as a gauge, and `mobc_pool_connections_open` was incremented as a counter. However, `mobc_pool_connections_opened_total` was described as a counter while `mobc_pool_connections_open` was described as a gauge. Simultaneously, `mobc_pool_connections_open` is decremented as a gauge when a connection is closed. Therefore,
- `mobc_pool_connections_opened_total` was incorrectly registered as a gauge instead of a counter.
- `mobc_pool_connections_open` was divided into two different metrics, where the gauge represented the negative number of closed connections, and the counter represented the total number of opened connections.

So, this PR increments `mobc_pool_connections_opened_total` as a **counter** and `mobc_pool_connections_open` as a **gauge** when a new pool connection is opened.