### PR TITLE
Better idle conn handling when max open is unlimited

### DIFF
--- a/src/time.rs
+++ b/src/time.rs
@@ -43,6 +43,7 @@ mod time {
     }
 
     /// Wait until duration has elapsed.
+    #[must_use = "This does nothing if you do not await"]
     pub fn delay_for(duration: Duration) -> Delay {
         Delay::new(duration)
     }


### PR DESCRIPTION
* Treat `max_idle == 0` as unlimited idle connections. In this case, open connections will be limited by `max_open`.
* Allow Builder to be configured with `max_idle > max_open` when `max_open == 0`, matching the behavior of `Pool::set_max_idle_conns()`

Fixes #81