### PR TITLE
Upgrade to metrics 0.21

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ async-trait = "0.1"
 futures-timer = "3.0.2"
 log = "0.4"
 thiserror = "1.0"
-metrics = "0.18"
+metrics = "0.21"
 tracing = { version = "0.1", features = ["attributes"] }
 tracing-subscriber = "0.3.11"
 


### PR DESCRIPTION
I considered making this `>0.18, <0.22` but from testing in my projects, cargo can be inconsistent in which version it picks when it encounters ranges, and that's a problem particularly with `metrics` since multiple copies means metrics may end up getting lost.
