### PR TITLE
chore: bump to redis 0.24.0

### DIFF
--- a/mobc-redis/Cargo.toml
+++ b/mobc-redis/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["redis", "pool", "async", "await"]
 
 [dependencies]
 mobc = { version = "0.8", path = ".." }
-redis = { version = "0.23.0" }
+redis = { version = "0.24.0" }
 
 [features]
 default = ["mobc/tokio", "redis/tokio-comp"]


### PR DESCRIPTION
Hi !

I'm naively proposing to bump to redis crate 0.24.0

But I know it contains breaking changes : https://github.com/redis-rs/redis-rs/releases/tag/redis-0.24.0

Would you like to also bump here ?