### PR TITLE
Fix compilation on newer nightly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "mobc"
 version = "0.8.3"
-authors = ["importcjj <importcjj@gmail.com>", "Garren Smith <garren.smith@gmail.com>"]
+authors = [
+    "importcjj <importcjj@gmail.com>",
+    "Garren Smith <garren.smith@gmail.com>",
+]
 edition = "2018"
 readme = "README.md"
 license = "MIT/Apache-2.0"
@@ -18,16 +21,20 @@ unstable = []
 
 [dependencies]
 futures-core = "0.3"
-futures-channel = { version = "0.3", features=["sink"] }
-futures-util = { version = "0.3", features=["sink"] }
-tokio = { version = "1", features=["rt", "rt-multi-thread", "time"], optional = true }
-async-std = { version = "1.0", features=["unstable"], optional = true }
+futures-channel = { version = "0.3", features = ["sink"] }
+futures-util = { version = "0.3", features = ["sink"] }
+tokio = { version = "1", features = [
+    "rt",
+    "rt-multi-thread",
+    "time",
+], optional = true }
+async-std = { version = "1.0", features = ["unstable"], optional = true }
 actix-rt = { version = "1", optional = true }
 async-trait = "0.1"
 futures-timer = "3.0.2"
 log = "0.4"
 thiserror = "1.0"
-metrics = "0.22.1"
+metrics = { version = "0.22.1", default-features = false }
 tracing = { version = "0.1", features = ["attributes"] }
 tracing-subscriber = "0.3.11"
 


### PR DESCRIPTION
Compilation on 2024-xx-xx nightly is broken because of metrics crate but can be fixed by removing unused feature.