### PR TITLE
docs: min_idle -> max_idle

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Sets the maximum number of connections managed by the pool.
 
 > 0 means unlimited, defaults to 10.
 
-#### min_idle
+#### max_idle
 
 Sets the maximum idle connection count maintained by the pool. The pool will maintain at most this many idle connections at all times, while respecting the value of max_open.
 


### PR DESCRIPTION
fixes a typo in the docs, ref https://github.com/importcjj/mobc/blob/main/src/config.rs#L12

(coincidentally I was looking to check if there is a concept of minimum pool size - eg: make sure that the pool always has at least X hot connections, so that an idle timeout can't result in an empty pool for bursty traffic patterns - though I guess setting `max_idle` rather than an idle timeout might be the recommendation here?)