### PR TITLE
fix: make the timings recorded in wait_duration and histogram consistent

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -442,8 +442,7 @@ impl<M: Manager> Pool<M> {
 
         let mut internals = self.0.internals.lock().await;
 
-        internals.wait_duration += wait_guard.elapsed();
-        drop(wait_guard);
+        internals.wait_duration += wait_guard.into_elapsed();
 
         let conn = internals.free_conns.pop();
         let internal_config = internals.config.clone();


### PR DESCRIPTION
Follow-up to #99, there was a comment from me that wasn't addressed: https://github.com/importcjj/mobc/pull/99#discussion_r1795031115.

We were computing the time spent waiting for a connection twice, once to add it to `internals.wait_duration` and once to record it in a histogram, so the latter is technically always larger. If the process is preempted by the kernel between these points, the timings can diverge significantly, especially in resource-constrained environments when running many threads/processes.

This PR changes the `DurationHistogramGuard::elapsed` method into a method that consumes `self` and records the elapsed time and returns in lockstep, only invoking `Instant::elapsed` once. The destructor that updates the histogram still exists to make the API misuse-resistant and because that's the contract of a guard, but it's not a code path that happens to be taken anywhere in practice right now.