### PR TITLE
User redis 0.28.

### DIFF
--- a/mobc-redis/Cargo.toml
+++ b/mobc-redis/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["redis", "pool", "async", "await"]
 
 [dependencies]
 mobc = { version = "0.8", path = ".." }
-redis = { version = "0.24.0" }
+redis = { version = "0.28" }
 
 [features]
 default = ["mobc/tokio", "redis/tokio-comp"]

--- a/mobc-redis/src/lib.rs
+++ b/mobc-redis/src/lib.rs
@@ -1,9 +1,9 @@
-pub use redis;
 pub use mobc;
+pub use redis;
 
 use mobc::async_trait;
 use mobc::Manager;
-use redis::aio::Connection;
+use redis::aio::MultiplexedConnection as Connection;
 use redis::{Client, ErrorKind};
 
 pub struct RedisConnectionManager {
@@ -22,7 +22,7 @@ impl Manager for RedisConnectionManager {
     type Error = redis::RedisError;
 
     async fn connect(&self) -> Result<Self::Connection, Self::Error> {
-        let c = self.client.get_async_connection().await?;
+        let c = self.client.get_multiplexed_async_connection().await?;
         Ok(c)
     }
 
@@ -34,5 +34,3 @@ impl Manager for RedisConnectionManager {
         Ok(conn)
     }
 }
-
-


### PR DESCRIPTION
The latest releases include safety & performance improvements. This change removes the usage of `redis::aio::Connection`, because it was deprecated due to being unsafe to use after errors.