### PR TITLE
chore(mobc): update metrics to 0.24.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ async-trait = "0.1"
 futures-timer = "3.0.2"
 log = "0.4"
 thiserror = "1.0"
-metrics = "0.23.0"
+metrics = "0.24.0"
 tracing = { version = "0.1", features = ["attributes"] }
 tracing-subscriber = "0.3.11"
 


### PR DESCRIPTION
Some useful crates (e.g. [actix-web-metrics](https://crates.io/crates/actix-web-metrics)) use metrics 0.24.0 and higher which doesn't collect metrics from this crate