### PR TITLE
feat(mobc): add manager type to metrics

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ async-trait = "0.1"
 futures-timer = "3.0.2"
 log = "0.4"
 thiserror = "1.0"
-metrics = "0.23.0"
+metrics = "0.24.0"
 tracing = { version = "0.1", features = ["attributes"] }
 tracing-subscriber = "0.3.11"
 


### PR DESCRIPTION
This can be useful when application uses more than one mobc pool

P.S. I think it shouldn't be implemented by changing `C` to the `M: Manager`
in Conn structs, so maybe it needs a refactor. Maybe an optional builder
argument for the pool name?